### PR TITLE
Allow grid data to be initialised manually rather than from file

### DIFF
--- a/castepfmtvis/celldata.py
+++ b/castepfmtvis/celldata.py
@@ -479,7 +479,8 @@ class UnitCell():
                  real_lat: npt.NDArray[np.float64] | None = None,
                  species: list | None = None,
                  frac_pos: npt.NDArray[np.float64] | None = None,
-                 cart_pos: npt.NDArray[np.float64] | None = None
+                 cart_pos: npt.NDArray[np.float64] | None = None,
+                 reduce_frac: bool = True
                  ):
         """Initialise the unit cell.
 
@@ -537,7 +538,9 @@ class UnitCell():
             # Have fractional coordinates so store them, then get Cartesian coordinates.
             assert frac_pos is not None
             # Rationalise fractional coordinates so that 0 <= frac_pos < 1 18/05/2025
-            frac_pos = reduce_frac_pts(frac_pos)
+            # Added option to disable rationalisation 09/06/2025
+            if reduce_frac is True:
+                frac_pos = reduce_frac_pts(frac_pos)
 
             self.frac_pos = frac_pos
             for i, pos in enumerate(frac_pos):

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -208,7 +208,7 @@ class GridData():
                  is_den: bool | None = None,
                  nblank_header: int = 1,
                  real_lat: npt.NDArray[np.float64] = None,
-                 dataarr: npt.NDArray[np.float64] = None,
+                 datarr: npt.NDArray[np.float64] = None,
                  units: str = ''
                  ):
         """
@@ -300,13 +300,13 @@ class GridData():
         else:  # Direct initialisation
             if real_lat is None:
                 raise ValueError('real_lat must be provided for direct initialisation')
-            if dataarr is None:
-                raise ValueError('dataarr must be provided for direct initialisation')
-            if dataarr.ndim != 3:
-                raise IndexError('dataarr must be a 3D array')
+            if datarr is None:
+                raise ValueError('datarr must be provided for direct initialisation')
+            if datarr.ndim != 3:
+                raise IndexError('datarr must be a 3D array')
 
             self.real_lat = real_lat
-            self.cur_data = dataarr
+            self.cur_data = datarr
 
             if len(units) == 0:
                 self.units = 'a.u.'

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -207,8 +207,8 @@ class GridData():
     def __init__(self, filename: str | None = None,
                  is_den: bool | None = None,
                  nblank_header: int = 1,
-                 real_lat: npt.NDArray[np.float64] = None,
-                 datarr: npt.NDArray[np.float64] = None,
+                 real_lat: npt.NDArray[np.float64] | None = None,
+                 datarr: npt.NDArray[np.float64] | None = None,
                  units: str = ''
                  ):
         """
@@ -314,7 +314,7 @@ class GridData():
                 self.units = units.strip()
 
             # Set other necessary info
-            self.fine_grid = self.cur_data.shape
+            self.fine_grid = np.array(self.cur_data.shape, dtype=int)
             self.npts = np.prod(self.fine_grid)
 
             # Set other dummy info

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -229,6 +229,14 @@ class GridData():
             number of blank lines after header
 
         """
+        # Declare empty arrays first and allocate later
+        self.charge: npt.NDArray[np.float64] | None = None
+        self.spin: npt.NDArray[np.float64] | None = None
+        self.ncspin: npt.NDArray[np.float64] | None = None
+        self.pot: npt.NDArray[np.float64] | None = None
+        self.ncpot: npt.NDArray[np.float64] | None = None
+        self.cur_data: npt.NDArray[np.float64] | None = None
+
         # 09/06/2025 Decide how we want to initialise the file
         if filename is not None:
             # Check if we have a density, otherwise look at the file extension
@@ -254,14 +262,6 @@ class GridData():
 
             # Extract the unit cell vectors
             self.real_lat = read_real_lat_fmt(filename)
-
-            # Declare empty arrays first and allocate later
-            self.charge: npt.NDArray[np.float64] | None = None
-            self.spin: npt.NDArray[np.float64] | None = None
-            self.ncspin: npt.NDArray[np.float64] | None = None
-            self.pot: npt.NDArray[np.float64] | None = None
-            self.ncpot: npt.NDArray[np.float64] | None = None
-            self.cur_data: npt.NDArray[np.float64] | None = None
 
             # Extract spin information and set non-collinear flag
             nsets = gridvals.shape[0]

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -208,7 +208,7 @@ class GridData():
                  is_den: bool | None = None,
                  nblank_header: int = 1,
                  real_lat: npt.NDArray[np.float64] = None,
-                 dataarr: np.NDArray[np.float64] = None,
+                 dataarr: npt.NDArray[np.float64] = None,
                  units: str = ''
                  ):
         """

--- a/castepfmtvis/pathplot.py
+++ b/castepfmtvis/pathplot.py
@@ -199,6 +199,7 @@ class PathData:
                          label_fontsize: int = 10,
                          xtick_rotation: int = 20,
                          label_rotation: int = 0,
+                         do_label: str = 'both',
                          ) -> mpl.axes._secondary_axes.SecondaryAxis:
         """Format the labels on the x-axis along the path on the provided axis.
 
@@ -219,6 +220,11 @@ class PathData:
         ax2 : mpl.axes._secondary_axes.SecondaryAxis
             Secondary axes for user labels
         """
+
+        # 09/06/2025 Allow control on which points are labelled. Useful for subplots.
+        if do_label not in ('both', 'frac', 'custom'):
+            raise ValueError('do_label must be one of: "both", "frac" or "custom"')
+
         # Determine the unique points in the user's path
         unique_pts = np.unique(self.spec_pts, axis=0)
 
@@ -256,9 +262,10 @@ class PathData:
         assert len(labels_flat) == len(indx_flat)
 
         # Add fractional coordinate labels
-        ax.set_xticks(indx_flat)
-        ax.set_xticklabels(labels_flat, rotation=xtick_rotation,
-                           ha='center', fontsize=xtick_fontsize)
+        if do_label in ('frac', 'both'):
+            ax.set_xticks(indx_flat)
+            ax.set_xticklabels(labels_flat, rotation=xtick_rotation,
+                               ha='center', fontsize=xtick_fontsize)
 
         # Now do the same for the user's custom labels
         labels_flat = []
@@ -267,12 +274,13 @@ class PathData:
                 labels_flat.append(j)
 
         # Add user custom labels
-        ax2 = ax.secondary_xaxis('top')
-        ax2.set_xticks(indx_flat)
-        ax2.set_xticklabels(labels_flat, rotation=label_rotation,
-                            ha='center', fontsize=label_fontsize)
+        if do_label in ('custom', 'both'):
+            ax2 = ax.secondary_xaxis('top')
+            ax2.set_xticks(indx_flat)
+            ax2.set_xticklabels(labels_flat, rotation=label_rotation,
+                                ha='center', fontsize=label_fontsize)
 
-        return ax2
+            return ax2
 
     def get_path_frac(self) -> npt.NDArray[np.float64]:
         """Get the list of points in the path in fractional coordinates.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='UTF-8') as file:
 
 setup(
     name='castepfmtvis',
-    version='3.2.0',
+    version='3.2.1',
     description='A tool for visualing formatted CASTEP potentials, charge and spin densities.',
     long_description=long_description,
     # Requires setuptools >= 38.6.0


### PR DESCRIPTION
The `GridData` class can now be initialised directly using input arrays saving the need for having to use CASTEP input files. 

In addition, one now has a choice of choosing whether `frac` or `custom` or both get set when using `PathData.format_pos_ticks`. 

Additionally, corrected a few type hinting mistakes