### PR TITLE
Read cell units in LATTICE_ABC and LATTICE_CART 

### DIFF
--- a/castepfmtvis/celldata.py
+++ b/castepfmtvis/celldata.py
@@ -413,7 +413,7 @@ def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
 
     real_lat: npt.NDArray[np.float64] = np.empty((3, 3), dtype=np.float64)
 
-    length_unit, start_pos = 'ANG', 0
+    length_unit = 'ANG'
     if have_cart is True:
         # Check if we have any lenght units we need to deal with. LENGTH_UNITS 05/08/2025
         if len(block_contents) == 4:
@@ -422,7 +422,7 @@ def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
             length_unit = block_contents[0].strip().upper()
         elif len(block_contents) == 3:
             # No units, continue as normal.
-            pass
+            start_pos = 0
         else:
             raise IOError('Improperly formatted LATTICE_CART block')
 
@@ -439,11 +439,25 @@ def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
         # First, we need to construct an ASE cell object so we need lattice positions
         symbols, scaled_positions, positions = _read_cell_pos(filename)
 
+        # Check if we have any lenght units we need to deal with. LENGTH_UNITS 05/08/2025
+        if len(block_contents) == 3:
+            # First line gives length units so read and convert later. LENGTH_UNITS 05/08/2025
+            len_pos, angle_pos = 1, 2
+            length_unit = block_contents[0].strip().upper()
+        elif len(block_contents) == 2:
+            # No units, continue as normal.
+            len_pos, angle_pos = 0, 1
+        else:
+            raise IOError('Improperly formatted LATTICE_ABC block')
+
         # Now parse arithmetic in LATTICE_ABC block
-        lengths = np.array([arit.parse_arithmetic(x) for x in block_contents[0].split()],
+        lengths = np.array([arit.parse_arithmetic(x) for x in block_contents[len_pos].split()],
                            dtype=np.float64)
-        angles = np.array([arit.parse_arithmetic(x) for x in block_contents[1].split()],
+        angles = np.array([arit.parse_arithmetic(x) for x in block_contents[angle_pos].split()],
                           dtype=np.float64)
+
+        # Convert units as necessary LENGTH_UNITS 05/08/2025
+        lengths = _convert_to_ang(lengths, length_unit)
 
         # Create cell and then find the Bravais lattice we need
         cellparams = np.concatenate((lengths, angles))

--- a/castepfmtvis/celldata.py
+++ b/castepfmtvis/celldata.py
@@ -259,10 +259,22 @@ def _read_cell_pos(filename: str) -> tuple[list,
     else:
         have_frac = True
 
-    # Parse arithmetic in the block
+    # When counting atoms, check if we have specified any    LENGTH_UNITS 13/10/2025
+    # length units units but only for Cartesian coordinates. LENGTH_UNITS 13/10/2025
+    length_unit = None
+    if have_frac is False:
+        length_unit = 'ANG'
+        try:
+            sp, x, y, z = block_contents[0].split()
+        except ValueError:
+            # Not a coordinate line so probably length unit
+            length_unit = block_contents[0].strip().upper()
+            block_contents = block_contents[1:]
+
     natoms = len(block_contents)
     species = [None for i in range(natoms)]
 
+    # Parse arithmetic in the block
     vals = np.empty((natoms, 3), dtype=np.float64)
     for i, line in enumerate(block_contents):
         species[i] = line.split()[0]
@@ -275,6 +287,8 @@ def _read_cell_pos(filename: str) -> tuple[list,
         frac_pos = vals
     else:
         cart_pos = vals
+        # Make sure to convert to Angstroms  LENGTH_UNITS 13/10/2025
+        cart_pos = _convert_to_ang(cart_pos, length_unit)
 
     return species, frac_pos, cart_pos
 
@@ -415,7 +429,7 @@ def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
 
     length_unit = 'ANG'
     if have_cart is True:
-        # Check if we have any lenght units we need to deal with. LENGTH_UNITS 05/08/2025
+        # Check if we have any length units we need to deal with. LENGTH_UNITS 05/08/2025
         if len(block_contents) == 4:
             # First line gives length units so read and convert later. LENGTH_UNITS 05/08/2025
             start_pos = 1

--- a/castepfmtvis/celldata.py
+++ b/castepfmtvis/celldata.py
@@ -18,6 +18,8 @@ import castepfmtvis.arithmetic as arit
 from castepfmtvis import io
 from castepfmtvis.utils import cart_to_frac, frac_to_cart, reduce_frac_pts
 
+from ase.units import Bohr
+
 __all__ = ['UnitCell', 'calc_recip_lat',
            'cell_cart_to_abc', 'cell_abc_to_cart']
 
@@ -381,6 +383,20 @@ def _get_bv_spg(cell: ase.Atoms) -> str:
     return bv_type
 
 
+def _convert_to_ang(val: float | npt.NDArray[np.float64], inunits: str):
+    """Convert length units to Angstroms."""
+    inunits = inunits.upper()
+    if inunits == 'ANG':
+        # Already in Angstroms, do nothing
+        pass
+    elif inunits == 'BOHR':
+        val *= Bohr
+    else:
+        raise ValueError('Unknown length unit: {inunits}')
+
+    return val
+
+
 def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
     """Read lattice vector from a cell file.
 
@@ -397,12 +413,27 @@ def _read_real_lat_cell(filename: str) -> npt.NDArray[np.float64]:
 
     real_lat: npt.NDArray[np.float64] = np.empty((3, 3), dtype=np.float64)
 
+    length_unit, start_pos = 'ANG', 0
     if have_cart is True:
+        # Check if we have any lenght units we need to deal with. LENGTH_UNITS 05/08/2025
+        if len(block_contents) == 4:
+            # First line gives length units so read and convert later. LENGTH_UNITS 05/08/2025
+            start_pos = 1
+            length_unit = block_contents[0].strip().upper()
+        elif len(block_contents) == 3:
+            # No units, continue as normal.
+            pass
+        else:
+            raise IOError('Improperly formatted LATTICE_CART block')
+
         # Loop around the lines containing each vector parsing any arithmetic that may be present
         # in a given component.
-        for i, vec in enumerate(block_contents):
+        for i, vec in enumerate(block_contents[start_pos:]):
             for j, comp in enumerate(vec.split()):
                 real_lat[i, j] = arit.parse_arithmetic(comp)
+
+        # Convert units as necessary LENGTH_UNITS 05/08/2025
+        real_lat = _convert_to_ang(real_lat, length_unit)
     else:
         # Try to construct lattice vectors from lengths and angles.
         # First, we need to construct an ASE cell object so we need lattice positions

--- a/castepfmtvis/celldata.py
+++ b/castepfmtvis/celldata.py
@@ -496,7 +496,20 @@ def calc_recip_lat(real_lat: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]
 class UnitCell():
     """Unit cell of a structure to visualise.
 
-    Currently, the data can only be read or initialised in a CASTEP format.
+    The cell can be initialised by directly by setting the necessary attributes, namely:
+    1. real_lat (in Angstroms)
+    2. frac_pos or cart_pos (in Angstroms)
+
+    Alternatively, it may be initialised by reading a CASTEP .cell file.
+    Note that by default, like in CASTEP, the default length unit is Angstroms
+    and will be assumed internally.
+
+    When doing so, arithmetic operations supported by CASTEP's parser will likewise be supported here.
+    Additionally, LIMITED support is availble for CASTEP's unit system where units for
+    certain keyword blocks may be provided and conversion done appropriately.
+
+    Currently, this is only supported for the LATTICE_ABC and LATTICE_CART blocks.
+    In particular, the POSITIONS_ABS block *must* be specified in angstroms.
 
     Attributes
     -------

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -19,7 +19,8 @@ import numpy.typing as npt
 
 from castepfmtvis import io
 
-__all__ = ['GridData', 'read_castep_fmt', 'read_real_lat_fmt']
+__all__ = ['GridData', 'read_castep_fmt', 'read_real_lat_fmt',
+           'den_spin_to_rho_up_down', 'rho_up_down_to_den_spin']
 
 
 def read_real_lat_fmt(filename: str) -> npt.NDArray[np.float64]:

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -453,3 +453,84 @@ class GridData():
             self.charge = charge
             self.spin = spin
             self.have_rho_up_down = False
+
+    def shift_grid(self, frac_shift: npt.NDArray[np.float64]):
+        """Perform cyclic shift on grid data with shift in frac. coords.
+
+        The shift is provided in fractional coordinates. All allocated data arrays
+        (charge, spin etc.) will be modified inplace.
+
+        Parameters
+        ----------
+        frac_shift : npt.NDArray[np.float64]
+            shift in fractional coordinates
+
+        Raises
+        ------
+        IndexError
+            frac_shift must be a 1D array of size 3.
+
+        """
+        return frac_shift_grid(self, frac_shift)
+
+
+def frac_shift_grid(griddata: GridData, frac_shift: npt.NDArray[np.float64]) -> GridData:
+    """Perform cyclic shift on grid data with shift in frac. coords.
+
+    This is useful if you have used shifted cells in the calculation for convenience
+    but make it hard to visualise the data.
+    Also useful for magnetic systems, .e.g. antiferromagnets, with degenerate ground states.
+
+    Parameters
+    ----------
+    griddata : GridData
+        grid data to shift
+    frac_shift : npt.NDArray[np.float64]
+        shift in fractional coordinates
+
+    Returns
+    -------
+    GridData
+        shifted data
+
+    Raises
+    ------
+    IndexError
+        frac_shift must be a 1D array of size 3.
+
+    """
+
+    if frac_shift.ndim != 1 and frac_shift.shape[0] != 3:
+        raise IndexError('frac_shift must be 1D array of size 3')
+
+    # Calculate shift in grid coordinates.
+    grid_shift = frac_shift * griddata.fine_grid
+
+    def _do_shift(datarr):
+        assert datarr.ndim == 3
+        for i in range(3):
+            datarr = np.roll(datarr, grid_shift[i], axis=i)
+        return datarr
+
+    # Shift grids as necessary
+    # Densities
+    if griddata.charge is not None:
+        griddata.charge = _do_shift(griddata.charge)
+    if griddata.spin is not None:
+        griddata.spin = _do_shift(griddata.spin)
+    if griddata.ncspin is not None:
+        for ns in range(3):
+            griddata.ncspin[ns, :, :, :] = _do_shift(griddata.ncspin[ns, :, :, :])
+
+    # Potentials
+    if griddata.pot is not None:
+        for ns in range(griddata.nspins):
+            griddata.pot[ns, :, :, :] = _do_shift(griddata.pot[ns, :, :, :])
+    if griddata.ncpot is not None:
+        for ns in range(3):
+            griddata.ncpot[ns, :, :, :] = _do_shift(griddata.ncpot[ns, :, :, :])
+
+    # Current plotting data - should always be allocated!
+    griddata.cur_data = _do_shift(griddata.cur_data)
+
+    return griddata

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -454,7 +454,7 @@ class GridData():
             self.spin = spin
             self.have_rho_up_down = False
 
-    def shift_grid(self, frac_shift: npt.NDArray[np.float64]):
+    def shift_grid_data(self, frac_shift: npt.NDArray[np.float64]):
         """Perform cyclic shift on grid data with shift in frac. coords.
 
         The shift is provided in fractional coordinates. All allocated data arrays
@@ -471,10 +471,10 @@ class GridData():
             frac_shift must be a 1D array of size 3.
 
         """
-        return frac_shift_grid(self, frac_shift)
+        return _frac_shift_grid(self, frac_shift)
 
 
-def frac_shift_grid(griddata: GridData, frac_shift: npt.NDArray[np.float64]) -> GridData:
+def _frac_shift_grid(griddata: GridData, frac_shift: npt.NDArray[np.float64]) -> GridData:
     """Perform cyclic shift on grid data with shift in frac. coords.
 
     This is useful if you have used shifted cells in the calculation for convenience

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from castepfmtvis import io
+from typing import Optional, Tuple
 
 __all__ = ['GridData', 'read_castep_fmt', 'read_real_lat_fmt',
            'den_spin_to_rho_up_down', 'rho_up_down_to_den_spin']
@@ -433,7 +434,36 @@ class GridData():
             )
         self.cur_data = arr
 
-    def get_rho_up_down(self, ret_arrs: bool = False):
+    def get_rho_up_down(self, ret_arrs: bool = False) -> Optional[Tuple[
+            npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+        """Get the charge density for each spin channel.
+
+        By default, the 'up' channel or whatever the first spin channel's charge density
+        is in CASTEP will be stored in the charge attribute while the 'down' or
+        second spin channel's density will be stored in the spin attribute.
+        Alternatively, the actual arrays can be returned by passing in ret_arrs=True.
+
+        If the respective arrays are already there, this function simply returns them.
+
+        Parameters
+        ----------
+        ret_arrs : bool
+            return actual arrays for each spin channel rather than
+            overriding the original ones in the class instance.
+
+        Returns
+        -------
+        rhoup, rhodown : npt.NDArray[np.float64]
+            charge arrays for spin up/down channel (if ret_arrs is True)
+
+        Raises
+        ------
+        TypeError
+            Data is not a density and thus has no 'rhoup' and 'rhodown'
+        AssertionError
+            Only one spin channel, hence no rhoup or rhodown.
+        """
+
         if self.nspins == 1:
             raise AssertionError('Cannot get rhoup and rhodown as only 1 spin channel.')
         if self.is_den is False:
@@ -453,7 +483,34 @@ class GridData():
             self.spin = rhodown
             self.have_rho_up_down = True
 
-    def get_charge_spin(self, ret_arrs: bool = False):
+    def get_charge_spin(self, ret_arrs: bool = False) -> Optional[Tuple[
+            npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+        """Get the total charge and spin density from spin channel densities.
+
+        This assumes that rhoup is in the charge attribute and rhodown is the spin attribute.
+        By default, this function will override the original arrays in the instance but the
+        arrays can instead be returned without overriding by passing in ret_arrs=True.
+
+        If the respective arrays are already there, this function simply returns them.
+
+        Parameters
+        ----------
+        ret_arrs : bool
+            return actual arrays for each spin channel rather than
+            overriding the original ones in the class instance.
+
+        Returns
+        -------
+        charge, spin : npt.NDArray[np.float64]
+            total charge density and spin density arrays (if ret_arrs is True)
+
+        Raises
+        ------
+        TypeError
+            Data is not a density and thus has no 'charge' and 'spin' densities.
+        AssertionError
+            Only one spin channel, hence no spin density.
+        """
         if self.nspins == 1:
             raise AssertionError('Cannot get charge and spin as only 1 spin channel.')
         if self.is_den is False:

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -241,6 +241,8 @@ class GridData():
     By default, this will default to the charge/npts or pot[0,:,:,:]
     depending on whether is_den is True or False.
 
+    IMPORTANT: Prior to plotting, the set_current_data method must be used to ensure the right set is plotted.
+
     Attributes
     -------
     is_den : bool
@@ -270,6 +272,17 @@ class GridData():
     have_rho_up_down : bool
         Flag for whether charge and spin arrays instead contain charge densities
         for each spin channel, i.e. rhoup and rhodown respectively.
+
+    Methods
+    --------
+    set_current_data
+        Set the data array that must be used for plotting.
+    get_rho_up_down
+        Get the charge densities for each spin channel from charge and spin densities.
+    get_charge_spin
+        Get the charge and spin densities from charge densities for each spin channel.
+    shift_grid_data
+        Performs a cyclic shift of grid data given a shift in fractional coordinates.
     """
 
     def __init__(self, filename: str | None = None,

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -142,6 +142,69 @@ def read_castep_fmt(filename: str, is_den: bool,
     return header, gridvals
 
 
+def den_spin_to_rho_up_down(charge: npt.NDArray[np.float64],
+                            spin: npt.NDArray[np.float64]) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Calculate charge densities for each collinear spin channel from total charge density and spin density.
+
+    Parameters
+    ----------
+    charge : npt.NDArray[np.float64]
+        total charge density on a real-space grid
+    spin : npt.NDArray[np.float64]
+        spin density on a real-space grid
+
+    Returns
+    -------
+    rhoup, rhodown : tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]
+        densities for each spin channel on a real-space grid
+
+    Raises
+    ------
+    AssertionError
+        Grid dimensions do not match between charge and spin.
+
+    """
+
+    if charge.shape != spin.shape:
+        raise AssertionError(f'Charge array has shape {charge.shape} ' +
+                             f'but spin array has {spin.shape}')
+
+    rhoup = (charge + spin)/2.0
+    rhodown = (charge - spin)/2.0
+    return rhoup, rhodown
+
+
+def rho_up_down_to_den_spin(rhoup: npt.NDArray[np.float64],
+                            rhodown: npt.NDArray[np.float64]) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Calculate total charge and spin density from charge densities for each collinear spin channel.
+
+    Parameters
+    ----------
+    rhoup : npt.NDArray[np.float64]
+        spin-up density on a real-space grid
+    rhodown : npt.NDArray[np.float64]
+        spin-down density on a real-space grid
+
+    Returns
+    -------
+    rhoup, rhodown : tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]
+        charge and spin densities a real-space grid
+
+    Raises
+    ------
+    AssertionError
+        Grid dimensions do not match between rhoup and rhodown.
+
+    """
+    if rhoup.shape != rhodown.shape:
+        raise AssertionError(f'rhoup array has shape {rhoup.shape} ' +
+                             f'but rhodown array has {rhodown.shape}')
+
+    charge = rhoup + rhodown
+    spin = rhoup - rhodown
+    return charge, spin
+
+
 class GridData():
     """Grid data from CASTEP to be visualised.
 
@@ -195,13 +258,17 @@ class GridData():
     units : str
         Units for the density or potential.
     charge: npt.NDArray[np.float64]
-        Charge density (units: electrons*grid_pts)
+        Charge density (units: electrons*grid_pts) - see however have_rho_up_down
     spin: npt.NDArray[np.float64]
-        Spin density (units: spin*grid_pts)
+        Spin density (units: spin*grid_pts)  - see however have_rho_up_down
     pot: npt.NDArray[np.float64]
         Potential for each (collinear) spin-channel (units: Hartrees)
     ncpot: npt.NDArray[np.float64]
         Potential for non-collinear spin-potential (units : Hartrees)
+
+    have_rho_up_down : bool
+        Flag for whether charge and spin arrays instead contain charge densities
+        for each spin channel, i.e. rhoup and rhodown respectively.
     """
 
     def __init__(self, filename: str | None = None,
@@ -236,6 +303,7 @@ class GridData():
         self.pot: npt.NDArray[np.float64] | None = None
         self.ncpot: npt.NDArray[np.float64] | None = None
         self.cur_data: npt.NDArray[np.float64] | None = None
+        self.have_rho_up_down = False
 
         # 09/06/2025 Decide how we want to initialise the file
         if filename is not None:
@@ -343,3 +411,44 @@ class GridData():
                 f'Data array shape {arr.shape} is not equal to fine_grid {self.fine_grid}'
             )
         self.cur_data = arr
+
+    def get_rho_up_down(self, ret_arrs: bool = False):
+        if self.nspins == 1:
+            raise AssertionError('Cannot get rhoup and rhodown as only 1 spin channel.')
+        if self.is_den is False:
+            raise TypeError('Cannot get rhoup and rhodown for non density data.')
+
+        # Retrieve/calculate rhoup and rhodown appropriately.
+        if self.have_rho_up_down is False:
+            rhoup, rhodown = den_spin_to_rho_up_down(self.charge, self.spin)
+        else:
+            rhoup, rhodown = self.charge, self.spin
+
+        if ret_arrs is True:
+            return rhoup, rhodown
+        elif self.have_rho_up_down is False:
+            # Overwrite charge and spin arrays with rhoup and rhodown respectively.
+            self.charge = rhoup
+            self.spin = rhodown
+            self.have_rho_up_down = True
+
+    def get_charge_spin(self, ret_arrs: bool = False):
+        if self.nspins == 1:
+            raise AssertionError('Cannot get charge and spin as only 1 spin channel.')
+        if self.is_den is False:
+            raise TypeError('Cannot get charge and spin for non density data.')
+
+        # Retrieve/calculate charge and spin appropriately.
+        # NB: charge array should be rhoup and spin array should be rhodown.
+        if self.have_rho_up_down is True:
+            charge, spin = rho_up_down_to_den_spin(self.charge, self.spin)
+        else:
+            charge, spin = self.charge, self.spin
+
+        if ret_arrs is True:
+            return charge, spin
+        elif self.have_rho_up_down is True:
+            # Overwrite charge and spin arrays.
+            self.charge = charge
+            self.spin = spin
+            self.have_rho_up_down = False

--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -258,6 +258,13 @@ class GridData():
         By default, this will default to the charge/den or pot[0,:,:,:] arrays
         depending on whether is_den is True or False.
 
+    nspins: int
+        The number of spin channels (1: spin unpolarised, 2: collinear)
+    have_nc: bool
+        Whether this is a non-collinear calculation or not.
+    is_den: bool
+        Current file is an electronic density.
+
     units : str
         Units for the density or potential.
     charge: npt.NDArray[np.float64]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='UTF-8') as file:
 
 setup(
     name='castepfmtvis',
-    version='3.2.1',
+    version='3.2.2',
     description='A tool for visualing formatted CASTEP potentials, charge and spin densities.',
     long_description=long_description,
     # Requires setuptools >= 38.6.0

--- a/test/castepdata_test.py
+++ b/test/castepdata_test.py
@@ -7,6 +7,12 @@ Author: Visagan Ravindran
 """
 import numpy as np
 from castepfmtvis.fmtdata import GridData
+from castepfmtvis.celldata import UnitCell
+from ase.units import Bohr
+
+WRITE_DEBUG_CELL = False
+
+print('Testing ability to read formatted data files')
 
 # Check if we can read charge densities
 ch_den = GridData('test.den_fmt')
@@ -68,3 +74,61 @@ assert np.isclose(spin_pot.pot[0, 34, 35, 35], -0.057691) and \
 assert np.isclose(spin_pot.pot[0, 39, 39, 38], -0.045735) and \
     np.isclose(spin_pot.pot[1, 39, 39, 38], -0.029914)
 print('SUCCESSFULLY READ SPIN POTENTIALS')
+
+
+def write_cell_contents(cell: UnitCell):
+    """Debug cell contents."""
+    print(' '*12 + 'Real Lattice (A)' + ' '*20+'Reciprocal Lattice(1/A)')
+    for v in cell.real_lat:
+        u = v / Bohr
+        print(f'{v[0]:12.6f}{v[1]:12.6f}{v[2]:12.6f} ' +
+              f'{u[0]:12.6f}{u[1]:12.6f}{u[2]:12.6f}')
+    print('\n'+' '*4+'Number of ions ', cell.nspecies)
+    print('-'*80)
+    print(' '*30+'Cell contents')
+    print('-'*80)
+    print(' '*11+'Fractional Coordinates'+' '*16+'Cartesian Coordinates(A)')
+    for i in range(cell.nspecies):
+        sp = cell.species[i]
+        frac = cell.frac_pos[i]
+        cart = cell.cart_pos[i]
+        print(f'{sp:2} {frac[0]:12.8f}{frac[1]:12.8f}{frac[2]:12.8f}  ' +
+              f'{cart[0]:12.8f}{cart[1]:12.8f}{cart[2]:12.8f}')
+
+
+# Initialise reference cell - this should also catch if we can do direct initialisation
+print('\nTesting ability to read cell files')
+ref_cell = UnitCell(
+    real_lat=np.array([
+        [0.0, 2.715500, 2.715500],
+        [2.715500, 0.0, 2.715500],
+        [2.715500, 2.715500, 0.0]]),
+    species=['Si', 'Si'],
+    frac_pos=np.array([
+        [0.0, 0.0, 0.0], [1/4, 1/4, 1/4]])
+)
+
+
+def check_cell(cellfile):
+    """Check cell initialises correctly."""
+    cell = UnitCell(cellfile)
+    if WRITE_DEBUG_CELL is True:
+        print('\nTesting cell: ', cellfile)
+        write_cell_contents(cell)
+        print('')
+
+    assert np.isclose(ref_cell.real_lat, cell.real_lat).all()
+    assert np.isclose(ref_cell.recip_lat, cell.recip_lat).all()
+    assert ref_cell.nspecies == cell.nspecies
+    assert ref_cell.species == cell.species
+    assert np.isclose(ref_cell.frac_pos, cell.frac_pos, atol=1e-11, rtol=5e-7).all()
+    assert np.isclose(ref_cell.cart_pos, cell.cart_pos).all()
+    print(f'SUCCESSFULLY READ {cellfile}')
+
+
+# Check that we can read cell files
+# NB: Only LATTICE_CART and LATTICE_ABC blocks supports units for now, POSITIONS_ABS must be in Angstroms!
+cellfiles = ('test_cells/lat_abc_ang.cell', 'test_cells/lat_abc_bohr.cell',
+             'test_cells/lat_cart_ang.cell', 'test_cells/lat_cart_bohr.cell')
+for f in cellfiles:
+    check_cell(f)

--- a/test/test.cell
+++ b/test/test.cell
@@ -1,4 +1,5 @@
 %block lattice_abc
+ang
 5.431 5.431 5.431
 90.00 90.00 90.00
 %endblock lattice_abc

--- a/test/test_cells/lat_abc_ang.cell
+++ b/test/test_cells/lat_abc_ang.cell
@@ -1,0 +1,10 @@
+%block lattice_abc
+ang
+5.431/sqrt(2) 5.431/sqrt(2) 5.431/sqrt(2)
+60.0 60.0 60.0
+%endblock lattice_abc
+
+%block positions_frac
+Si 0.0 0.0 0.0
+Si 1/4 1/4 1/4
+%endblock positions_frac

--- a/test/test_cells/lat_abc_bohr.cell
+++ b/test/test_cells/lat_abc_bohr.cell
@@ -1,0 +1,10 @@
+%block lattice_abc
+bohr
+10.263103/sqrt(2) 10.263103/sqrt(2) 10.263103/sqrt(2)
+60.0 60.0 60.0
+%endblock lattice_abc
+
+%block positions_frac
+Si 0.0 0.0 0.0
+Si 1/4 1/4 1/4
+%endblock positions_frac

--- a/test/test_cells/lat_cart_ang.cell
+++ b/test/test_cells/lat_cart_ang.cell
@@ -1,0 +1,11 @@
+%block lattice_cart
+ang
+0.0000000 5.43100/2 5.43100/2
+5.43100/2 0.0000000 5.43100/2
+5.43100/2 5.43100/2 0.0000000
+%endblock lattice_cart
+
+%block positions_frac
+Si 0.0 0.0 0.0
+Si 1/4 1/4 1/4
+%endblock positions_frac

--- a/test/test_cells/lat_cart_bohr.cell
+++ b/test/test_cells/lat_cart_bohr.cell
@@ -1,0 +1,11 @@
+%block lattice_cart
+bohr
+0.0000000 10.263103/2 10.263103/2
+10.263103/2 0.0000000 10.263103/2
+10.263103/2 10.263103/2 0.0000000
+%endblock lattice_cart
+
+%block positions_frac
+Si 0.0 0.0 0.0
+Si 1/4 1/4 1/4
+%endblock positions_frac


### PR DESCRIPTION
The `LATTICE_ABC` and `LATTICE_CART` block now reads length units when specified. In addition to the default Angstrom unit `ANG`, `Bohr` is also supported - other units require conversions to be implemented. 

In addition, also added some miscellaneous functions to: 

- shift grid data by fractional coordinates (previously the shift needed to be specified in terms of the grid coordinates/indices)
- conversion routines to change a density from charge and spin to $\rho^\uparrow$ and $\rho^\downarrow$. 
- Added missing documentation to `GridData` class. 
- Added tests for reading cells with units in `test/castepdata_test.py`. 
- Updated original `test/test.cell` to have `ang` so we know we can deal with units in lattice vectors or parameters (Technically still missing coverage for `POSITIONS_ABS` block).  