### PR TITLE
Expanded initialisation of GridData to allow all attributes to now be initialised.

### DIFF
--- a/castepfmtvis/fmtdata.py
+++ b/castepfmtvis/fmtdata.py
@@ -295,9 +295,16 @@ class GridData():
 
     def __init__(self, filename: str | None = None,
                  is_den: bool | None = None,
+                 nspins: int | None = None,
+                 have_nc: bool | None = None,
                  nblank_header: int = 1,
                  real_lat: npt.NDArray[np.float64] | None = None,
                  datarr: npt.NDArray[np.float64] | None = None,
+                 charge: npt.NDArray[np.float64] | None = None,
+                 spin: npt.NDArray[np.float64] | None = None,
+                 ncspin: npt.NDArray[np.float64] | None = None,
+                 pot: npt.NDArray[np.float64] | None = None,
+                 ncpot: npt.NDArray[np.float64] | None = None,
                  units: str = ''
                  ):
         """
@@ -306,6 +313,8 @@ class GridData():
           1) Read formatted CASTEP rectilinear grid data
           2) Specifying the relevant attributes directly.
              NB: The grid data will be stored in the cur_data class.
+
+        When initialising directly, both real_lat and dataarr must be set.
 
         Parameters
         ----------
@@ -317,6 +326,7 @@ class GridData():
         nblank_header : int
             number of blank lines after header
 
+        All other arguments follow attributes in class definition.
         """
         # Declare empty arrays first and allocate later
         self.charge: npt.NDArray[np.float64] | None = None
@@ -407,10 +417,33 @@ class GridData():
             self.fine_grid = np.array(self.cur_data.shape, dtype=int)
             self.npts = np.prod(self.fine_grid)
 
-            # Set other dummy info
-            self.is_den = False
-            self.nspins = 1
-            self.have_nc = False
+            # Set other (potentially) dummy info
+            if is_den is None:
+                self.is_den = False
+            else:
+                self.is_den = is_den
+
+            if nspins is None:
+                self.nspins = 1
+            else:
+                self.nspins = nspins
+
+            if have_nc is None:
+                self.have_nc = False
+            else:
+                self.have_nc = have_nc
+
+            # Set auxiliary arrays that may have been provided 08/10/2025
+            if charge is not None:
+                self.charge = charge
+            if spin is not None:
+                self.spin = spin
+            if ncspin is not None:
+                self.ncpot = ncpot
+            if pot is not None:
+                self.pot = pot
+            if ncpot is not None:
+                self.ncpot = ncpot
 
     def set_current_data(self, arr: npt.NDArray[np.float64]):
         """Set the current data to use for plotting.

--- a/test/castepdata_test.py
+++ b/test/castepdata_test.py
@@ -11,69 +11,149 @@ from castepfmtvis.celldata import UnitCell
 from ase.units import Bohr
 
 WRITE_DEBUG_CELL = False
+WRITE_DEBUG_GRIDDATA = False
+
+
+def dump_griddata(griddata: GridData):
+    def allocated(arr):
+        if arr is None:
+            return 0
+        else:
+            return arr.shape
+    print('Fine grid: ', griddata.fine_grid)
+    print('Number of grid points: ', griddata.npts)
+    print('Have density: ', griddata.is_den)
+    print('No of spins: ', griddata.is_den)
+    print('Have non-collinear: ', griddata.have_nc)
+    print('Real lattice: ', griddata.real_lat)
+    print('Shape (charge,spin,ncspin): ',
+          allocated(griddata.charge), allocated(griddata.spin), griddata.ncspin)
+    print('Shape (pot,ncpot): ',
+          allocated(griddata.pot), allocated(griddata.ncpot))
+
+
+def init_griddata(src: GridData) -> GridData:
+    """Initialise a griddata instance manually based on source data."""
+    outdata = GridData(real_lat=filedata.real_lat, datarr=filedata.cur_data,
+                       is_den=filedata.is_den,
+                       nspins=filedata.nspins, have_nc=filedata.have_nc,
+                       charge=filedata.charge, spin=filedata.spin,
+                       ncspin=filedata.ncspin,
+                       pot=filedata.pot, ncpot=filedata.ncpot
+                       )
+    return outdata
+
+
+def check_den(den: GridData):
+    """Test density is read correctly."""
+    if WRITE_DEBUG_GRIDDATA is True:
+        dump_griddata(den)
+    assert den.is_den is True
+    assert den.have_rho_up_down is False
+    assert den.charge is not None
+    assert den.have_nc is False
+    assert den.nspins == 1
+    assert np.isclose(den.charge[0, 0, 0], 235.881121)
+    assert np.isclose(den.charge[30, 26, 6], 51.133352)
+    assert np.isclose(den.charge[9, 23, 16], 16.818431)
+    assert np.isclose(den.charge[34, 35, 35], 27.202500)
+    assert np.isclose(den.charge[35, 35, 35], 77.023717)
+
+
+def check_pot(poten: GridData):
+    """Test potential is read correctly."""
+    if WRITE_DEBUG_GRIDDATA is True:
+        dump_griddata(poten)
+    assert poten.is_den is False
+    assert poten.nspins == 1
+    assert poten.have_nc is False
+    assert poten.pot is not None
+    assert np.isclose(poten.pot[0, 20, 20, 20], -2.900180)
+    assert np.isclose(poten.pot[0, 30, 20, 5], -0.086498)
+    assert np.isclose(poten.pot[0, 9, 23, 6], -0.143155)
+    assert np.isclose(poten.pot[0, 9, 23, 16], -0.490368)
+    assert np.isclose(poten.pot[0, 34, 35, 35], 0.034852)
+
+
+def check_den_spin(den: GridData):
+    """Test a spin-polarised density data is read correctly."""
+    if WRITE_DEBUG_GRIDDATA is True:
+        dump_griddata(den)
+    assert den.is_den is True
+    assert den.have_rho_up_down is False
+    assert den.have_nc is False
+    assert den.nspins == 2
+    assert den.charge is not None
+    assert den.spin is not None
+
+    assert np.isclose(den.charge[0, 0, 0], 0.037294) and \
+        np.isclose(den.spin[0, 0, 0], 0.037295)
+    assert np.isclose(den.charge[30, 20, 5], 0.304386) and \
+        np.isclose(den.spin[30, 20, 5], 0.304386)
+    assert np.isclose(den.charge[9, 23, 6], 0.296179) and \
+        np.isclose(den.spin[9, 23, 6], 0.296179)
+    assert np.isclose(den.charge[9, 23, 16], 1.519513) and \
+        np.isclose(den.spin[9, 23, 16], 1.519513)
+    assert np.isclose(den.charge[34, 35, 35], 0.072161) and \
+        np.isclose(den.spin[34, 35, 35], 0.072161)
+    assert np.isclose(den.charge[39, 39, 38], 0.044832) and \
+        np.isclose(den.spin[39, 39, 38], 0.044833)
+    assert np.isclose(den.charge[39, 39, 39], 0.042089) and \
+        np.isclose(den.spin[39, 39, 39], 0.042090)
+
+
+def check_pot_spin(poten: GridData):
+    """Test a spin-polarised potential data is read correctly."""
+    if WRITE_DEBUG_GRIDDATA is True:
+        dump_griddata(poten)
+    assert poten.is_den is False
+    assert poten.nspins == 2
+    assert poten.have_nc is False
+    assert poten.pot is not None
+    assert np.isclose(poten.pot[0, 30, 20, 5], -0.107548) and \
+        np.isclose(poten.pot[1, 30, 20, 5], -0.064133)
+    assert np.isclose(poten.pot[0, 9, 23, 6], -0.108213) and \
+        np.isclose(poten.pot[1, 9, 23, 6], -0.065665)
+    assert np.isclose(poten.pot[0, 9, 23, 16], -0.219881) and \
+        np.isclose(poten.pot[1, 9, 23, 16], -0.125023)
+    assert np.isclose(poten.pot[0, 34, 35, 35], -0.057691) and \
+        np.isclose(poten.pot[1, 34, 35, 35], -0.037401)
+    assert np.isclose(poten.pot[0, 39, 39, 38], -0.045735) and \
+        np.isclose(poten.pot[1, 39, 39, 38], -0.029914)
+
 
 print('Testing ability to read formatted data files')
-
-# Check if we can read charge densities
-ch_den = GridData('test.den_fmt')
-assert ch_den.is_den is True
-assert ch_den.charge is not None and ch_den.nspins == 1 and ch_den.have_nc is False
-assert np.isclose(ch_den.charge[0, 0, 0], 235.881121)
-assert np.isclose(ch_den.charge[30, 26, 6], 51.133352)
-assert np.isclose(ch_den.charge[9, 23, 16], 16.818431)
-assert np.isclose(ch_den.charge[34, 35, 35], 27.202500)
-assert np.isclose(ch_den.charge[35, 35, 35], 77.023717)
-print('SUCCESSFULLY READ CHARGE DENSITY')
+# Check if we can read/initialise charge densities
+filedata = GridData('test.den_fmt')
+check_den(filedata)
+print('SUCCESSFULLY read charge density')
+mygriddata = init_griddata(filedata)
+check_den(mygriddata)
+print('SUCCESSFULLY initialised charge density')
 
 # Check if we can read local potentials
-locpot = GridData('nospin.pot_fmt')
-assert locpot.is_den is False
-assert locpot.nspins == 1 and locpot.have_nc is False
-assert locpot.pot is not None
-assert np.isclose(locpot.pot[0, 20, 20, 20], -2.900180)
-assert np.isclose(locpot.pot[0, 30, 20, 5], -0.086498)
-assert np.isclose(locpot.pot[0, 9, 23, 6], -0.143155)
-assert np.isclose(locpot.pot[0, 9, 23, 16], -0.490368)
-assert np.isclose(locpot.pot[0, 34, 35, 35], 0.034852)
-print('SUCCESSFULLY READ LOCAL POTENTIAL')
+filedata = GridData('nospin.pot_fmt')
+check_pot(filedata)
+print('SUCCESSFULLY read local potential')
+mygriddata = init_griddata(filedata)
+check_pot(mygriddata)
+print('SUCCESSFULLY initialised local potential')
 
 # Check if we can read can read charge and spin densities
-spin_den = GridData('test_spin.den_fmt')
-assert spin_den.is_den is True
-assert spin_den.nspins == 2 and spin_den.have_nc is False
-assert spin_den.charge is not None and spin_den.spin is not None
-assert np.isclose(spin_den.charge[0, 0, 0], 0.037294) and \
-    np.isclose(spin_den.spin[0, 0, 0], 0.037295)
-assert np.isclose(spin_den.charge[30, 20, 5], 0.304386) and \
-    np.isclose(spin_den.spin[30, 20, 5], 0.304386)
-assert np.isclose(spin_den.charge[9, 23, 6], 0.296179) and \
-    np.isclose(spin_den.spin[9, 23, 6], 0.296179)
-assert np.isclose(spin_den.charge[9, 23, 16], 1.519513) and \
-    np.isclose(spin_den.spin[9, 23, 16], 1.519513)
-assert np.isclose(spin_den.charge[34, 35, 35], 0.072161) and \
-    np.isclose(spin_den.spin[34, 35, 35], 0.072161)
-assert np.isclose(spin_den.charge[39, 39, 38], 0.044832) and \
-    np.isclose(spin_den.spin[39, 39, 38], 0.044833)
-assert np.isclose(spin_den.charge[39, 39, 39], 0.042089) and \
-    np.isclose(spin_den.spin[39, 39, 39], 0.042090)
-print('SUCCESSFULLY READ CHARGE AND SPIN DENSITY')
+filedata = GridData('test_spin.den_fmt')
+check_den_spin(filedata)
+print('SUCCESSFULLY read charge and spin density')
+mygriddata = init_griddata(filedata)
+check_den_spin(mygriddata)
+print('SUCCESSFULLY initialised charge and spin density')
 
 # Check if we can read spin potentials
-spin_pot = GridData('test_spin.pot_fmt')
-assert spin_pot.is_den is False
-assert spin_pot.nspins == 2 and spin_pot.have_nc is False
-assert spin_pot.pot is not None
-assert np.isclose(spin_pot.pot[0, 30, 20, 5], -0.107548) and \
-    np.isclose(spin_pot.pot[1, 30, 20, 5], -0.064133)
-assert np.isclose(spin_pot.pot[0, 9, 23, 6], -0.108213) and \
-    np.isclose(spin_pot.pot[1, 9, 23, 6], -0.065665)
-assert np.isclose(spin_pot.pot[0, 9, 23, 16], -0.219881) and \
-    np.isclose(spin_pot.pot[1, 9, 23, 16], -0.125023)
-assert np.isclose(spin_pot.pot[0, 34, 35, 35], -0.057691) and \
-    np.isclose(spin_pot.pot[1, 34, 35, 35], -0.037401)
-assert np.isclose(spin_pot.pot[0, 39, 39, 38], -0.045735) and \
-    np.isclose(spin_pot.pot[1, 39, 39, 38], -0.029914)
-print('SUCCESSFULLY READ SPIN POTENTIALS')
+filedata = GridData('test_spin.pot_fmt')
+check_pot_spin(filedata)
+print('SUCCESSFULLY read spin potentials')
+mygriddata = init_griddata(filedata)
+check_pot_spin(mygriddata)
+print('SUCCESSFULLY initialised spin potentials')
 
 
 def write_cell_contents(cell: UnitCell):


### PR DESCRIPTION
Previously, one only initialised the `current_data` and `real_lat` in `GridData` were initialised. 

This PR allows pretty much everything to be initialised directly, although only the former two are the minimum required to directly initialise a class instance. 

The other attributes are given 'sane'(-ish) default values, if not provided notably:
* `nspins = 1`
* `have_ncm=False`
* `is_den=False`
* Uninitialised attributes that contain numpy arrays such as `spin` and `charge` default to None. 